### PR TITLE
feat(copy-script): Effect schema + generate-copy pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"format": "prettier --write .",
 		"test:unit": "vitest",
 		"test": "npm run test:unit -- --run",
-		"gen": "wrangler types"
+		"gen": "wrangler types",
+		"generate-copy": "tsx scripts/generate-copy.ts"
 	},
 	"devDependencies": {
 		"@anthropic-ai/sdk": "^0.82.0",

--- a/scripts/generate-copy.ts
+++ b/scripts/generate-copy.ts
@@ -1,0 +1,252 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { Effect, Schedule, Schema } from 'effect'
+import Anthropic from '@anthropic-ai/sdk'
+import OpenAI from 'openai'
+import { CopyFileSchema, type CopyFile, type LocaleCopy } from '../src/lib/copy/schema.ts'
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const LOCALES = ['nl', 'de', 'fr', 'es', 'it'] as const
+type TranslationLocale = (typeof LOCALES)[number]
+
+const LOCALE_NAMES: Record<TranslationLocale, string> = {
+	nl: 'Dutch (Nederlands)',
+	de: 'German (Deutsch)',
+	fr: 'French (Français)',
+	es: 'Spanish (Español)',
+	it: 'Italian (Italiano)',
+}
+
+// Retry: up to 3 retries with exponential backoff starting at 1s
+const RETRY_POLICY = Schedule.exponential('1 second').pipe(Schedule.take(3))
+
+// ── Provider setup ─────────────────────────────────────────────────────────
+
+const parseModel = (raw: string): { provider: string; model: string } => {
+	const idx = raw.indexOf('/')
+	if (idx === -1) return { provider: 'anthropic', model: raw }
+	return { provider: raw.slice(0, idx), model: raw.slice(idx + 1) }
+}
+
+/**
+ * Constructs a `callModel` function based on available env vars and COPY_MODEL.
+ * Routing: ANTHROPIC_API_KEY + anthropic/ prefix → Anthropic SDK (prefix stripped).
+ * Otherwise → OpenRouter via openai SDK (requires OPENROUTER_API_KEY).
+ * Exits non-zero if no usable key is present.
+ */
+const makeCallModel = (): ((prompt: string) => Effect.Effect<string, Error>) => {
+	const rawModel = process.env.COPY_MODEL ?? 'anthropic/claude-haiku-4-5'
+	const { provider, model } = parseModel(rawModel)
+
+	if (provider === 'anthropic' && process.env.ANTHROPIC_API_KEY) {
+		const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+		console.log(`Provider: Anthropic  Model: ${model}`)
+		return (prompt) =>
+			Effect.tryPromise({
+				try: () =>
+					client.messages
+						.create({
+							model,
+							max_tokens: 4096,
+							messages: [{ role: 'user', content: prompt }],
+						})
+						.then((r) => {
+							const block = r.content[0]
+							if (block.type !== 'text') throw new Error('Unexpected non-text block from Anthropic')
+							return block.text
+						}),
+				catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+			})
+	}
+
+	if (process.env.OPENROUTER_API_KEY) {
+		const client = new OpenAI({
+			baseURL: 'https://openrouter.ai/api/v1',
+			apiKey: process.env.OPENROUTER_API_KEY,
+		})
+		console.log(`Provider: OpenRouter  Model: ${rawModel}`)
+		return (prompt) =>
+			Effect.tryPromise({
+				try: () =>
+					client.chat.completions
+						.create({ model: rawModel, messages: [{ role: 'user', content: prompt }] })
+						.then((r) => {
+							const content = r.choices[0]?.message?.content
+							if (!content) throw new Error('Empty response from OpenRouter')
+							return content
+						}),
+				catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+			})
+	}
+
+	const hint =
+		provider === 'anthropic'
+			? 'Set ANTHROPIC_API_KEY, or change COPY_MODEL to an OpenRouter model and set OPENROUTER_API_KEY.'
+			: 'Set OPENROUTER_API_KEY.'
+	console.error(`\nError: No API key available for provider "${provider}".\n${hint}`)
+	process.exit(1)
+}
+
+// ── Prompts ────────────────────────────────────────────────────────────────
+
+const LOCALE_SCHEMA = `{"throttled":["string x30"],"clear":["string x30"],"weekend":["string x30"]}`
+
+const buildEnglishPrompt = (dedup: string[]): string => {
+	const dedupBlock =
+		dedup.length > 0
+			? `\nDO NOT REPEAT any of these strings from last week:\n${dedup.map((s) => `- ${s}`).join('\n')}\n`
+			: ''
+
+	return `Generate copy for a site called amibeinganthrottled.com. It tells Claude Pro and Max subscribers whether they're currently in Anthropic's peak throttle window (weekdays 5–11 AM PT), how long until it ends, and makes the whole thing a bit of a joke.
+
+Generate exactly 30 unique strings for each of the 3 states below.
+
+TONE:
+- Short, dry, sarcastic — like a site that knows exactly what it is
+- "throttled": commiserate with the user, mild outrage, nod to the irony of paying for a subscription that throttles you
+- "clear": encouraging, slightly smug, tell them to get on with it
+- "weekend": chill, existential, gently suggest a life outside Claude
+- Max ~12 words per string
+- No emojis, no exclamation marks, no corporate warmth
+${dedupBlock}
+Return ONLY raw JSON matching this exact structure — no markdown, no backticks, no preamble:
+${LOCALE_SCHEMA}`
+}
+
+const buildTranslationPrompt = (locale: TranslationLocale, english: LocaleCopy): string =>
+	`Translate the following JSON copy strings from English to ${LOCALE_NAMES[locale]}.
+
+IMPORTANT: Translate IDIOMATICALLY, not literally. Adapt phrases culturally so the dry, sarcastic tone lands naturally in ${LOCALE_NAMES[locale]}. For example, "go crazy" should become the idiomatic equivalent in the target language, not a word-for-word rendering.
+
+TONE: Keep it short, dry, sarcastic. Max ~12 words per string. No emojis, no exclamation marks.
+
+Return ONLY raw JSON matching the exact same structure as the input — no markdown, no backticks, no preamble:
+
+${JSON.stringify(english, null, 2)}`
+
+// ── Validation ─────────────────────────────────────────────────────────────
+
+const LocaleSchemaEffect = Schema.Struct({
+	throttled: Schema.Array(Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(80))).check(
+		Schema.isMinLength(30),
+		Schema.isMaxLength(30),
+	),
+	clear: Schema.Array(Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(80))).check(
+		Schema.isMinLength(30),
+		Schema.isMaxLength(30),
+	),
+	weekend: Schema.Array(Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(80))).check(
+		Schema.isMinLength(30),
+		Schema.isMaxLength(30),
+	),
+})
+
+const parseAndValidateLocale = (label: string, response: string): Effect.Effect<LocaleCopy, Error> =>
+	Effect.try({
+		try: () => JSON.parse(response) as unknown,
+		catch: () => new Error(`[${label}] Response was not valid JSON`),
+	}).pipe(
+		Effect.flatMap((parsed) =>
+			Schema.decodeUnknownEffect(LocaleSchemaEffect)(parsed).pipe(
+				Effect.mapError((e) => new Error(`[${label}] Schema validation failed: ${e.message}`)),
+			),
+		),
+	)
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+const main = async () => {
+	const date = new Date().toISOString().slice(0, 10)
+	const copyDir = 'src/lib/copy'
+	const outPath = `${copyDir}/${date}.json`
+	const indexPath = `${copyDir}/index.json`
+
+	// Idempotency check — before any API calls
+	if (existsSync(outPath)) {
+		console.log(`Copy for ${date} already exists, skipping.`)
+		process.exit(0)
+	}
+
+	const callModel = makeCallModel()
+	const call = (prompt: string) => Effect.retry(callModel(prompt), RETRY_POLICY)
+
+	// Ensure copy directory exists
+	if (!existsSync(copyDir)) {
+		mkdirSync(copyDir, { recursive: true })
+	}
+
+	// Load previous week's English strings for dedup (best-effort)
+	let dedup: string[] = []
+	try {
+		const index = JSON.parse(readFileSync(indexPath, 'utf8')) as { current?: string }
+		if (index.current) {
+			const prevPath = `${copyDir}/${index.current}.json`
+			if (existsSync(prevPath)) {
+				const prev = JSON.parse(readFileSync(prevPath, 'utf8')) as {
+					en?: { throttled?: string[]; clear?: string[]; weekend?: string[] }
+				}
+				dedup = [
+					...(prev.en?.throttled ?? []),
+					...(prev.en?.clear ?? []),
+					...(prev.en?.weekend ?? []),
+				].filter((s): s is string => typeof s === 'string')
+			}
+		}
+	} catch {
+		// No previous week or malformed index — proceed without dedup
+	}
+
+	console.log(`\nGenerating copy for ${date}...`)
+	if (dedup.length > 0) console.log(`Loaded ${dedup.length} dedup strings from previous week.`)
+
+	const program = Effect.gen(function* () {
+		// Step 1: Generate English
+		console.log('\n[1/2] Generating English copy...')
+		const enResponse = yield* call(buildEnglishPrompt(dedup))
+		const english = yield* parseAndValidateLocale('en', enResponse)
+		console.log('      ✓ English validated (90 strings)')
+
+		// Step 2: Translate all 5 locales in parallel
+		console.log('\n[2/2] Translating to nl, de, fr, es, it in parallel...')
+		const translationResults = yield* Effect.all(
+			LOCALES.map((locale) =>
+				call(buildTranslationPrompt(locale, english)).pipe(
+					Effect.flatMap((r) => parseAndValidateLocale(locale, r)),
+					Effect.mapError((e) => new Error(e.message)),
+				),
+			),
+			{ concurrency: 'unbounded' },
+		)
+		LOCALES.forEach((l) => console.log(`      ✓ ${l} validated`))
+
+		const translations = Object.fromEntries(
+			LOCALES.map((locale, i) => [locale, translationResults[i]]),
+		) as Record<TranslationLocale, LocaleCopy>
+
+		// Step 3: Assemble and final-validate the complete file
+		const assembled = { date, en: english, ...translations }
+		const validated = yield* Schema.decodeUnknownEffect(CopyFileSchema)(assembled).pipe(
+			Effect.mapError((e) => new Error(`Final validation failed: ${e.message}`)),
+		)
+
+		return validated
+	})
+
+	let result: CopyFile
+	try {
+		result = await Effect.runPromise(program)
+	} catch (e) {
+		console.error('\n✗ Generation failed:', e instanceof Error ? e.message : String(e))
+		process.exit(1)
+	}
+
+	// Write — only after all validation passes
+	writeFileSync(outPath, JSON.stringify(result, null, 2) + '\n', 'utf8')
+	writeFileSync(indexPath, JSON.stringify({ current: date }, null, 2) + '\n', 'utf8')
+
+	console.log(`\n✓ ${outPath}`)
+	console.log(`✓ ${indexPath} → ${date}`)
+	console.log('\nDone.')
+}
+
+main()

--- a/src/lib/copy/schema.ts
+++ b/src/lib/copy/schema.ts
@@ -1,0 +1,28 @@
+import { Schema } from 'effect'
+
+// A single copy string — non-empty, max 80 chars
+const CopyString = Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(80))
+
+// Exactly 30 copy strings
+const Strings30 = Schema.Array(CopyString).check(Schema.isMinLength(30), Schema.isMaxLength(30))
+
+// One locale's copy — three states, 30 strings each
+const LocaleSchema = Schema.Struct({
+	throttled: Strings30,
+	clear: Strings30,
+	weekend: Strings30,
+})
+
+// Full weekly copy file — date + 6 locales
+export const CopyFileSchema = Schema.Struct({
+	date: Schema.String.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2}$/)),
+	en: LocaleSchema,
+	nl: LocaleSchema,
+	de: LocaleSchema,
+	fr: LocaleSchema,
+	es: LocaleSchema,
+	it: LocaleSchema,
+})
+
+export type CopyFile = typeof CopyFileSchema.Type
+export type LocaleCopy = typeof LocaleSchema.Type


### PR DESCRIPTION
## Closes #4

Adds the Effect Schema definition for weekly copy files and the TypeScript generation script that calls the model API, validates all 6 locales, and writes the output atomically.

### What's in this PR

**`src/lib/copy/schema.ts`** — Effect Schema v4 definition, single source of truth for the weekly copy file shape:
- `CopyFileSchema`: 6 locale keys (`en`, `nl`, `de`, `fr`, `es`, `it`), each with 3 state arrays (`throttled`, `clear`, `weekend`) of exactly 30 strings, validated with `isMinLength`/`isMaxLength`. Date field validated as `YYYY-MM-DD` via `isPattern`.
- Exports `CopyFile` and `LocaleCopy` types.

**`scripts/generate-copy.ts`** — TypeScript pipeline invoked via `tsx`:
- **Provider routing** driven by `COPY_MODEL` (`provider/model` format, default `anthropic/claude-haiku-4-5`): `anthropic/` prefix + `ANTHROPIC_API_KEY` → Anthropic SDK with prefix stripped; otherwise → OpenRouter via `openai` SDK (requires `OPENROUTER_API_KEY`). Exits non-zero with a clear message if the required key is absent.
- **Idempotency** check at startup — exits 0 silently if today's file already exists, before any API calls.
- **Retry** via `Schedule.exponential('1 second').pipe(Schedule.take(3))` on each call.
- **English generation** with prior-week dedup block.
- **5 translation locales in parallel** via `Effect.all(..., { concurrency: 'unbounded' })`.
- **Schema validation** via `Schema.decodeUnknownEffect(CopyFileSchema)` on each locale and on the assembled file. No files written until all 6 pass.

**`package.json`**: added `"generate-copy": "tsx scripts/generate-copy.ts"` script entry.

### Tests

- **Type check**: `npx tsc --noEmit --allowImportingTsExtensions scripts/generate-copy.ts src/lib/copy/schema.ts` — clean
- **Schema validation**: tested via Node REPL — valid input passes, short arrays and bad date patterns correctly rejected
- **No key → exit 1**: `COPY_MODEL=anthropic/claude-haiku-4-5 pnpm generate-copy` → `Error: No API key available for provider "anthropic"` + exit 1 ✓
- **Idempotency**: pre-existing file → `Copy for YYYY-MM-DD already exists, skipping.` + exit 0 ✓
- **OpenRouter fallback routing**: `COPY_MODEL=openai/gpt-4o ANTHROPIC_API_KEY=sk-test pnpm generate-copy` → `Error: No API key available for provider "openai". Set OPENROUTER_API_KEY.` + exit 1 ✓
- **Real API run**: not yet tested — no key available locally. Script logic and all error paths are verified.

### Acceptance criteria

- [x] `src/lib/copy/schema.ts` exports `CopyFileSchema` and `CopyFile` type
- [x] Schema enforces: 6 locale keys, 3 state arrays, exactly 30 items each, `minLength: 1`, `maxLength: 80`, date matches `YYYY-MM-DD`
- [ ] `pnpm generate-copy` runs locally and produces a correctly-shaped output file — pending API key
- [x] Output validated with `Schema.decodeUnknownEffect(CopyFileSchema)` before any file is written
- [x] Script exits non-zero on: invalid JSON response, schema validation failure, API error, missing required key
- [x] No files written on partial success
- [x] Script is idempotent — re-running for the same date exits 0 without calling the API
- [x] Idempotency check happens before any API calls
- [x] `src/lib/copy/index.json` updated with new `current` date on success
- [x] `COPY_MODEL=anthropic/claude-haiku-4-5` + `ANTHROPIC_API_KEY` → uses Anthropic SDK, strips prefix
- [x] `COPY_MODEL=anthropic/claude-haiku-4-5` + only `OPENROUTER_API_KEY` → uses OpenRouter with full model string
- [x] Neither key present → exits non-zero with clear error before any API call
- [x] `.env.example` present with all three vars documented

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `generate-copy` pipeline with Effect schema validation for localized copy files
> - Adds [scripts/generate-copy.ts](https://github.com/vesta-cx/amibeinganthrottled.com/pull/11/files#diff-f2b60a2fc69bea0f8ad874293f1423b2d9a0fac64a25d9dc1785514bf04eb4dd) which generates 30 English strings per state (`throttled`, `clear`, `weekend`) via an LLM, then translates them to nl, de, fr, es, it in parallel, writing a dated JSON file to `src/lib/copy/` and updating `index.json`.
> - Selects LLM provider at runtime based on `COPY_MODEL` and available API keys (`ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY`); exits with code 1 if neither is present.
> - Adds [src/lib/copy/schema.ts](https://github.com/vesta-cx/amibeinganthrottled.com/pull/11/files#diff-97dd15d61c2b4c6b505d26cabb667868ee59d15ca17c0a04e578f04eebe66b99) with Effect schemas enforcing exactly 30 strings (1–80 chars each) per section per locale, plus a full `CopyFileSchema` with a YYYY-MM-DD date field.
> - Skips generation if today's output file already exists (idempotent) and applies a 3-attempt exponential retry policy to all model calls.
> - Registers the script as `npm run generate-copy` in [package.json](https://github.com/vesta-cx/amibeinganthrottled.com/pull/11/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8697151.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->